### PR TITLE
Changed desktop start time, misc layout stuff.

### DIFF
--- a/client/app/scripts/services/youtubeplayerAPI.js
+++ b/client/app/scripts/services/youtubeplayerAPI.js
@@ -514,11 +514,12 @@ var ytp_debug, ytp_debugII;
           
           self.pause();  
           self.noise();
-          self.end(-90); 
-          self.start(19.25);     
+          //self.end(-90); 
+          self.start(1);     
           verifyRates();
           
           $timeout(function(){ 
+    
             self.initializing = false; 
             $rootScope.$broadcast(readyEvent.name);
           }, 500);

--- a/client/app/templates/player.html
+++ b/client/app/templates/player.html
@@ -14,8 +14,7 @@
         <div id="quickset-phone-row"
              layout="column" 
              flex="100" 
-             ng-show="!player.API.initializing" 
-             hide-gt-md>
+             ng-show="!player.API.initializing && player.API.mobile" >
           
           <div layout="row" class="quickset-top-row" flex layout-align="start start">
       

--- a/client/app/templates/playercontrols.html
+++ b/client/app/templates/playercontrols.html
@@ -21,7 +21,7 @@
   </div>
 
   <!-- APP Row -->
-  <div class="controls-block controls-background controls-top" layout="row"> 
+  <div class="controls-block controls-background controls-top" layout="row" layout-fill> 
 
     <!-- Opaque cover for the App controls before inital video is ready -->
     <div class="controls-loading-cover" 
@@ -171,7 +171,7 @@
           </span> 
 
           <!-- Desktop Quick Setter & Timestamp --> 
-          <div id="middle-quickset-block" class="desktop-quickset-block" ng-show="!player.API.mobile">
+          <div id="middle-quickset-block" class="desktop-quickset-block" ng-show="!player.API.mobile" hide-sm>
                 
             <div layout="row" class="quickset-top-row" flex layout-align="start end">
         


### PR DESCRIPTION
Setting end & start in the initial play event sequence causes the spinner to show in the new player, which is loaded by default on all windows systems apparently. 